### PR TITLE
Add tables for projects and leaders

### DIFF
--- a/my_app/app/__init__.py
+++ b/my_app/app/__init__.py
@@ -3,9 +3,12 @@ from flask import Flask
 from .database import db
 
 
-def create_app():
+def create_app(config_object: str | None = "app.config.Config", **overrides):
     app = Flask(__name__)
-    app.config.from_object("app.config.Config")
+    if config_object:
+        app.config.from_object(config_object)
+    if overrides:
+        app.config.update(overrides)
 
     db.init_app(app)
 

--- a/my_app/app/models.py
+++ b/my_app/app/models.py
@@ -1,7 +1,40 @@
 from .database import db
 
 
-class Project(db.Model):  # type: ignore[name-defined]
+class DevelopmentLeader(db.Model):  # type: ignore[name-defined]
+    """Represents a leader in charge of development projects."""
+
+    __tablename__ = "development_leader"
+
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(120), nullable=False)
-    description = db.Column(db.Text)
+    name = db.Column(db.String(120), nullable=False, unique=True)
+    email = db.Column(db.String(120), nullable=False)
+
+    projects = db.relationship(
+        "Project",
+        back_populates="leader",
+        primaryjoin="Project.development_leader == DevelopmentLeader.name",
+    )
+
+
+class Project(db.Model):  # type: ignore[name-defined]
+    """A project belonging to a development team."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False, unique=True)
+    description = db.Column(db.Text, nullable=False)
+    primary_contact_name = db.Column(db.String(120), nullable=False)
+    primary_contact_email = db.Column(db.String(120), nullable=False)
+    url = db.Column(db.String(255))
+
+    development_leader = db.Column(
+        db.String(120),
+        db.ForeignKey("development_leader.name"),
+        nullable=False,
+    )
+
+    leader = db.relationship(
+        "DevelopmentLeader",
+        back_populates="projects",
+        primaryjoin="Project.development_leader == DevelopmentLeader.name",
+    )

--- a/my_app/tests/unit/test_models.py
+++ b/my_app/tests/unit/test_models.py
@@ -1,0 +1,26 @@
+from app import create_app
+from app.database import db
+from app.models import DevelopmentLeader, Project
+
+
+def test_create_project_with_leader():
+    app = create_app(SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    with app.app_context():
+        db.create_all()
+        leader = DevelopmentLeader(name="Alice", email="alice@example.com")
+        db.session.add(leader)
+        db.session.commit()
+
+        project = Project(
+            name="Example",
+            description="A sample project",
+            primary_contact_name="Bob",
+            primary_contact_email="bob@example.com",
+            url="http://example.com",
+            development_leader="Alice",
+        )
+        db.session.add(project)
+        db.session.commit()
+
+        fetched = Project.query.filter_by(name="Example").one()
+        assert fetched.leader.name == "Alice"


### PR DESCRIPTION
## Summary
- expand models to include `DevelopmentLeader` and extended `Project`
- allow `create_app` to accept config overrides
- add unit test for creating a project with a leader

## Testing
- `black my_app/app my_app/tests`
- `isort my_app/app my_app/tests`
- `flake8 my_app/app`
- `mypy my_app/app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c030dca888329a9b20538351c0e22