### PR TITLE
Add CRUD API endpoints

### DIFF
--- a/my_app/app/views.py
+++ b/my_app/app/views.py
@@ -1,4 +1,20 @@
-from flask import Blueprint, jsonify
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy.exc import NoResultFound
+
+from app.services import (
+    create_leader,
+    create_project,
+    delete_leader,
+    delete_project,
+    get_leader,
+    get_project,
+    list_leaders,
+    list_projects,
+    update_leader,
+    update_project,
+)
 
 bp = Blueprint("views", __name__)
 
@@ -6,3 +22,83 @@ bp = Blueprint("views", __name__)
 @bp.route("/api/health")
 def health():
     return jsonify({"status": "ok"})
+
+
+def project_to_dict(project) -> dict:
+    """Serialize a Project model to a dictionary."""
+    return {
+        "id": project.id,
+        "name": project.name,
+        "description": project.description,
+        "primary_contact_name": project.primary_contact_name,
+        "primary_contact_email": project.primary_contact_email,
+        "url": project.url,
+        "development_leader": project.development_leader,
+    }
+
+
+def leader_to_dict(leader) -> dict:
+    """Serialize a DevelopmentLeader model to a dictionary."""
+    return {
+        "id": leader.id,
+        "name": leader.name,
+        "email": leader.email,
+    }
+
+
+@bp.route("/api/projects", methods=["GET", "POST"])
+def projects():
+    if request.method == "POST":
+        data = request.get_json() or {}
+        project = create_project(**data)
+        return jsonify(project_to_dict(project)), 201
+
+    projects_list = list_projects()
+    return jsonify([project_to_dict(p) for p in projects_list])
+
+
+@bp.route("/api/projects/<int:project_id>", methods=["GET", "PUT", "DELETE"])
+def project_detail(project_id: int):
+    try:
+        if request.method == "GET":
+            project = get_project(project_id)
+            return jsonify(project_to_dict(project))
+
+        if request.method == "PUT":
+            updates = request.get_json() or {}
+            project = update_project(project_id, **updates)
+            return jsonify(project_to_dict(project))
+
+        delete_project(project_id)
+        return jsonify({"status": "deleted"})
+    except NoResultFound:
+        return jsonify({"error": "not found"}), 404
+
+
+@bp.route("/api/leaders", methods=["GET", "POST"])
+def leaders():
+    if request.method == "POST":
+        data = request.get_json() or {}
+        leader = create_leader(**data)
+        return jsonify(leader_to_dict(leader)), 201
+
+    leaders_list = list_leaders()
+    return jsonify([leader_to_dict(ldr) for ldr in leaders_list])
+
+
+@bp.route("/api/leaders/<int:leader_id>", methods=["GET", "PUT", "DELETE"])
+def leader_detail(leader_id: int):
+    try:
+        if request.method == "GET":
+            leader = get_leader(leader_id)
+            return jsonify(leader_to_dict(leader))
+
+        if request.method == "PUT":
+            updates = request.get_json() or {}
+            leader = update_leader(leader_id, **updates)
+            return jsonify(leader_to_dict(leader))
+
+        delete_leader(leader_id)
+        return jsonify({"status": "deleted"})
+    except NoResultFound:
+        return jsonify({"error": "not found"}), 404

--- a/my_app/tests/integration/test_views.py
+++ b/my_app/tests/integration/test_views.py
@@ -1,0 +1,60 @@
+from app import create_app
+from app.database import db
+
+
+def setup_app():
+    app = create_app(SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_project_and_leader_endpoints():
+    app = setup_app()
+    client = app.test_client()
+
+    # create leader
+    res = client.post(
+        "/api/leaders",
+        json={"name": "Alice", "email": "alice@example.com"},
+    )
+    assert res.status_code == 201
+    leader = res.get_json()
+    assert leader["name"] == "Alice"
+
+    # list leaders
+    res = client.get("/api/leaders")
+    assert res.status_code == 200
+    assert any(ldr["name"] == "Alice" for ldr in res.get_json())
+
+    # create project
+    project_payload = {
+        "name": "Project X",
+        "description": "Secret",
+        "primary_contact_name": "Bob",
+        "primary_contact_email": "bob@example.com",
+        "url": "http://example.com",
+        "development_leader": "Alice",
+    }
+    res = client.post("/api/projects", json=project_payload)
+    assert res.status_code == 201
+    project = res.get_json()
+    project_id = project["id"]
+
+    # update project
+    res = client.put(
+        f"/api/projects/{project_id}",
+        json={"description": "Updated"},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["description"] == "Updated"
+
+    # delete project
+    res = client.delete(f"/api/projects/{project_id}")
+    assert res.status_code == 200
+    assert res.get_json()["status"] == "deleted"
+
+    # verify deletion
+    res = client.get(f"/api/projects/{project_id}")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- expand `app/views.py` with CRUD routes for projects and leaders
- add integration tests for the new routes

## Testing
- `flake8 app tests`
- `mypy app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c20c8c02883298fc092a4e05c6590