### PR TITLE
Add CLI utilities

### DIFF
--- a/my_app/app/cli/__init__.py
+++ b/my_app/app/cli/__init__.py
@@ -2,6 +2,7 @@ import click
 from flask.cli import with_appcontext
 
 from app.database import db
+from app.services import create_leader, create_project, list_projects
 
 
 @click.command("init-db")
@@ -11,5 +12,43 @@ def init_db_command():
     click.echo("Initialized the database.")
 
 
+@click.command("create-leader")
+@click.argument("name")
+@click.argument("email")
+@with_appcontext
+def create_leader_command(name: str, email: str) -> None:
+    """Create a development leader."""
+    leader = create_leader(name=name, email=email)
+    click.echo(f"Created leader {leader.name} (id={leader.id})")
+
+
+@click.command("list-projects")
+@with_appcontext
+def list_projects_command() -> None:
+    """List all projects."""
+    projects = list_projects()
+    for project in projects:
+        click.echo(f"{project.id}: {project.name}")
+
+
+@click.command("seed-data")
+@with_appcontext
+def seed_data_command() -> None:
+    """Insert initial example data."""
+    leader = create_leader(name="Alice", email="alice@example.com")
+    create_project(
+        name="Example",
+        description="A sample project",
+        primary_contact_name="Bob",
+        primary_contact_email="bob@example.com",
+        url="http://example.com",
+        development_leader=leader.name,
+    )
+    click.echo("Seed data inserted.")
+
+
 def register(app):
     app.cli.add_command(init_db_command)
+    app.cli.add_command(create_leader_command)
+    app.cli.add_command(list_projects_command)
+    app.cli.add_command(seed_data_command)

--- a/my_app/tests/unit/test_cli.py
+++ b/my_app/tests/unit/test_cli.py
@@ -1,0 +1,41 @@
+from click.testing import CliRunner
+
+from app import create_app
+from app.cli import (
+    create_leader_command,
+    list_projects_command,
+    seed_data_command,
+)
+from app.database import db
+from app.services import list_leaders
+
+
+def setup_app():
+    app = create_app(SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_create_leader_command():
+    app = setup_app()
+    runner = CliRunner()
+    with app.app_context():
+        result = runner.invoke(
+            create_leader_command,
+            ["Alice", "alice@example.com"],
+        )
+        assert result.exit_code == 0
+        assert len(list_leaders()) == 1
+
+
+def test_seed_data_and_list_projects():
+    app = setup_app()
+    runner = CliRunner()
+    with app.app_context():
+        result = runner.invoke(seed_data_command)
+        assert result.exit_code == 0
+        result = runner.invoke(list_projects_command)
+        assert result.exit_code == 0
+        assert "Example" in result.output


### PR DESCRIPTION
## Summary
- extend CLI with commands to create leaders, list projects and seed sample data
- add CLI unit tests

## Testing
- `flake8 my_app/app/cli/__init__.py`
- `flake8 my_app/tests/unit/test_cli.py`
- `mypy my_app/app/cli/__init__.py`
- `mypy my_app/tests/unit/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c20d4d43c83299c301ad5b8188c80