### PR TITLE
Add comprehensive test coverage

### DIFF
--- a/my_app/tests/conftest.py
+++ b/my_app/tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+from app import create_app
+from app.database import db
+
+@pytest.fixture()
+def app():
+    app = create_app(SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+@pytest.fixture()
+def runner(app):
+    return app.test_cli_runner()

--- a/my_app/tests/integration/test_api_routes.py
+++ b/my_app/tests/integration/test_api_routes.py
@@ -1,0 +1,53 @@
+import pytest
+
+
+def test_leader_routes(client, app):
+    res = client.post("/api/leaders", json={"name": "Alice", "email": "a@e.com"})
+    assert res.status_code == 201
+    leader_id = res.get_json()["id"]
+
+    res = client.get("/api/leaders")
+    assert any(ldr["id"] == leader_id for ldr in res.get_json())
+
+    res = client.get(f"/api/leaders/{leader_id}")
+    assert res.status_code == 200
+
+    res = client.put(f"/api/leaders/{leader_id}", json={"email": "new@e.com"})
+    assert res.get_json()["email"] == "new@e.com"
+
+    res = client.delete(f"/api/leaders/{leader_id}")
+    assert res.get_json()["status"] == "deleted"
+
+    res = client.get(f"/api/leaders/{leader_id}")
+    assert res.status_code == 404
+
+
+def test_project_routes(client, app):
+    # create leader first
+    leader = client.post("/api/leaders", json={"name": "Bob", "email": "b@e.com"}).get_json()
+
+    payload = {
+        "name": "Proj",
+        "description": "Desc",
+        "primary_contact_name": "PC",
+        "primary_contact_email": "pc@e.com",
+        "development_leader": leader["name"],
+    }
+    res = client.post("/api/projects", json=payload)
+    assert res.status_code == 201
+    proj_id = res.get_json()["id"]
+
+    res = client.get("/api/projects")
+    assert any(p["id"] == proj_id for p in res.get_json())
+
+    res = client.get(f"/api/projects/{proj_id}")
+    assert res.get_json()["name"] == "Proj"
+
+    res = client.put(f"/api/projects/{proj_id}", json={"description": "Up"})
+    assert res.get_json()["description"] == "Up"
+
+    res = client.delete(f"/api/projects/{proj_id}")
+    assert res.get_json()["status"] == "deleted"
+
+    res = client.get(f"/api/projects/{proj_id}")
+    assert res.status_code == 404

--- a/my_app/tests/unit/test_cli_commands.py
+++ b/my_app/tests/unit/test_cli_commands.py
@@ -1,0 +1,28 @@
+from app.cli import init_db_command, create_leader_command, seed_data_command, list_projects_command
+from app.services import list_leaders, list_projects
+
+
+def test_init_db_command(runner):
+    result = runner.invoke(init_db_command)
+    assert result.exit_code == 0
+    # running again should still succeed
+    result = runner.invoke(init_db_command)
+    assert result.exit_code == 0
+
+
+def test_create_leader_command(runner, app):
+    result = runner.invoke(create_leader_command, ["Alice", "alice@example.com"])
+    assert result.exit_code == 0
+    with app.app_context():
+        assert len(list_leaders()) == 1
+
+
+def test_seed_data_and_list_projects(runner, app):
+    result = runner.invoke(seed_data_command)
+    assert result.exit_code == 0
+    with app.app_context():
+        assert len(list_projects()) == 1
+
+    result = runner.invoke(list_projects_command)
+    assert result.exit_code == 0
+    assert "Example" in result.output

--- a/my_app/tests/unit/test_development_leader_service.py
+++ b/my_app/tests/unit/test_development_leader_service.py
@@ -1,0 +1,31 @@
+import pytest
+from sqlalchemy.exc import NoResultFound
+
+from app.services import (
+    create_leader,
+    delete_leader,
+    get_leader,
+    list_leaders,
+    update_leader,
+)
+
+
+def test_create_and_list_leaders(app):
+    with app.app_context():
+        leader = create_leader(name="Alice", email="alice@example.com")
+        leaders = list_leaders()
+        assert leader in leaders
+
+
+def test_get_update_delete_leader(app):
+    with app.app_context():
+        leader = create_leader(name="Bob", email="bob@example.com")
+        fetched = get_leader(leader.id)
+        assert fetched.email == "bob@example.com"
+
+        updated = update_leader(leader.id, email="bobby@example.com")
+        assert updated.email == "bobby@example.com"
+
+        delete_leader(leader.id)
+        with pytest.raises(NoResultFound):
+            get_leader(leader.id)

--- a/my_app/tests/unit/test_project_service.py
+++ b/my_app/tests/unit/test_project_service.py
@@ -1,0 +1,46 @@
+import pytest
+from sqlalchemy.exc import NoResultFound
+
+from app.services import (
+    create_leader,
+    create_project,
+    delete_project,
+    get_project,
+    list_projects,
+    update_project,
+)
+
+
+def test_create_and_list_projects(app):
+    with app.app_context():
+        leader = create_leader(name="Alice", email="alice@example.com")
+        project = create_project(
+            name="Example",
+            description="A sample project",
+            primary_contact_name="Bob",
+            primary_contact_email="bob@example.com",
+            development_leader=leader.name,
+        )
+        projects = list_projects()
+        assert project in projects
+
+
+def test_get_update_delete_project(app):
+    with app.app_context():
+        leader = create_leader(name="Carol", email="carol@example.com")
+        project = create_project(
+            name="Demo",
+            description="Test",
+            primary_contact_name="Dan",
+            primary_contact_email="dan@example.com",
+            development_leader=leader.name,
+        )
+        fetched = get_project(project.id)
+        assert fetched.name == "Demo"
+
+        updated = update_project(project.id, description="Updated")
+        assert updated.description == "Updated"
+
+        delete_project(project.id)
+        with pytest.raises(NoResultFound):
+            get_project(project.id)


### PR DESCRIPTION
## Summary
- add pytest fixtures for app, client and runner
- add unit tests for each service module
- test CLI commands with click.testing
- cover API routes with integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c27453e488329a5d32c80e6e893b6