### PR TITLE
Add usage and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # project-tracker
-A simple web service to manage a list of projects within a development organization
+
+A simple web service to manage a list of projects within a development organization.
+
+See [full documentation](my_app/docs/README.md) for API details, CLI usage and development workflow.

--- a/my_app/docs/README.md
+++ b/my_app/docs/README.md
@@ -1,1 +1,98 @@
 # Documentation
+
+## API Routes
+
+### Health Check
+- **GET `/api/health`**
+  - Response: `{"status": "ok"}`
+
+### Projects
+- **GET `/api/projects`**
+  - Returns a list of projects.
+- **POST `/api/projects`**
+  - Body parameters:
+    - `name` (string, required)
+    - `description` (string, required)
+    - `primary_contact_name` (string, required)
+    - `primary_contact_email` (string, required)
+    - `url` (string, optional)
+    - `development_leader` (string, required)
+  - Sample response:
+    ```json
+    {
+      "id": 1,
+      "name": "Example",
+      "description": "A sample project",
+      "primary_contact_name": "Bob",
+      "primary_contact_email": "bob@example.com",
+      "url": "http://example.com",
+      "development_leader": "Alice"
+    }
+    ```
+- **GET `/api/projects/<id>`**
+  - Returns a single project or `404` if not found.
+- **PUT `/api/projects/<id>`**
+  - Accepts any of the project fields to update.
+- **DELETE `/api/projects/<id>`**
+  - Response: `{"status": "deleted"}`
+
+### Development Leaders
+- **GET `/api/leaders`**
+  - Returns a list of leaders.
+- **POST `/api/leaders`**
+  - Body parameters:
+    - `name` (string, required)
+    - `email` (string, required)
+- **GET `/api/leaders/<id>`**
+  - Returns a single leader or `404` if not found.
+- **PUT `/api/leaders/<id>`**
+  - Accepts `name` and/or `email` to update.
+- **DELETE `/api/leaders/<id>`**
+  - Response: `{"status": "deleted"}`
+
+## CLI Usage
+
+All commands are available through the Flask CLI:
+
+- `flask init-db` – initialize the SQLite database.
+- `flask create-leader NAME EMAIL` – create a new development leader.
+- `flask list-projects` – list all projects.
+- `flask seed-data` – insert example leader and project.
+
+## Database Models
+
+### DevelopmentLeader
+- `id` – primary key
+- `name` – unique string
+- `email` – string
+- Relationship: one `DevelopmentLeader` has many `Project` records.
+
+### Project
+- `id` – primary key
+- `name` – unique string
+- `description` – text
+- `primary_contact_name` – string
+- `primary_contact_email` – string
+- `url` – optional string
+- `development_leader` – foreign key referencing `DevelopmentLeader.name`
+
+## Development Setup & Workflow
+
+Install dependencies and formatting tools:
+
+```bash
+pip install -r requirements.txt
+pip install black isort flake8 mypy
+```
+
+Common tasks:
+
+| Task            | Command                   |
+|-----------------|---------------------------|
+| Format code     | `black app/ tests/`       |
+| Sort imports    | `isort app/ tests/`       |
+| Run linter      | `flake8 app/`             |
+| Type checking   | `mypy app/`               |
+| Run tests       | `pytest`                  |
+| Coverage report | `pytest --cov=app`        |
+


### PR DESCRIPTION
## Summary
- document API routes, CLI commands, database models, and dev workflow
- link the new docs from the project README

## Testing
- `pytest -q`
- `black --check my_app`
- `isort --check-only my_app`
- `flake8 my_app`
- `mypy my_app/app`


------
https://chatgpt.com/codex/tasks/task_b_686c298319dc8329930cb8187b021cf0