### PR TITLE
Add SPA API service with proxy

### DIFF
--- a/my_app/docs/README.md
+++ b/my_app/docs/README.md
@@ -96,3 +96,15 @@ Common tasks:
 | Run tests       | `pytest`                  |
 | Coverage report | `pytest --cov=app`        |
 
+### SPA Development
+
+The frontend is built with Vite. During development, run the dev server:
+
+```bash
+cd frontend && npm start
+```
+
+The Vite configuration proxies API requests under `/api` to the Flask app
+running on port `5000`, so the SPA can communicate with the backend without
+cross-origin issues.
+

--- a/my_app/frontend/src/LeaderList.jsx
+++ b/my_app/frontend/src/LeaderList.jsx
@@ -1,17 +1,26 @@
 import React, { useState, useEffect } from 'react';
+import {
+  getLeaders,
+  createLeader,
+  deleteLeader,
+} from './services/api';
 
 function LeaderList() {
   const [leaders, setLeaders] = useState([]);
   const [form, setForm] = useState({ name: '', email: '' });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  const fetchLeaders = () => {
-    fetch('/api/leaders')
-      .then((res) => res.json())
-      .then((data) => setLeaders(data));
+  const fetchLeadersList = () => {
+    setLoading(true);
+    getLeaders()
+      .then((data) => setLeaders(data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
   };
 
   useEffect(() => {
-    fetchLeaders();
+    fetchLeadersList();
   }, []);
 
   const handleChange = (e) => {
@@ -21,24 +30,28 @@ function LeaderList() {
 
   const handleCreate = (e) => {
     e.preventDefault();
-    fetch('/api/leaders', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form),
-    })
+    createLeader(form)
       .then(() => {
         setForm({ name: '', email: '' });
-        fetchLeaders();
-      });
+        fetchLeadersList();
+      })
+      .catch((err) => setError(err.message));
   };
 
   const handleDelete = (id) => {
-    fetch(`/api/leaders/${id}`, { method: 'DELETE' }).then(() => fetchLeaders());
+    deleteLeader(id)
+      .then(() => fetchLeadersList())
+      .catch((err) => setError(err.message));
   };
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
 
   return (
     <div>
       <h2>Development Leaders</h2>
+      {error && <p>Error: {error}</p>}
       <form onSubmit={handleCreate}>
         <input
           name="name"

--- a/my_app/frontend/src/ProjectList.jsx
+++ b/my_app/frontend/src/ProjectList.jsx
@@ -1,14 +1,26 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { getProjects } from './services/api';
 
 function ProjectList() {
   const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch('/api/projects')
-      .then((res) => res.json())
-      .then((data) => setProjects(data));
+    getProjects()
+      .then((data) => setProjects(data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
   }, []);
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
 
   return (
     <div>

--- a/my_app/frontend/src/services/api.js
+++ b/my_app/frontend/src/services/api.js
@@ -1,0 +1,62 @@
+const API_BASE = '/api';
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE}${path}`, options);
+  let data = null;
+  try {
+    if (response.status !== 204) {
+      data = await response.json();
+    }
+  } catch (_) {
+    // ignore JSON parse errors
+  }
+  if (!response.ok) {
+    const message = data && data.error ? data.error : response.statusText;
+    throw new Error(message);
+  }
+  return data;
+}
+
+export function getProjects() {
+  return request('/projects');
+}
+
+export function getProject(id) {
+  return request(`/projects/${id}`);
+}
+
+export function createProject(project) {
+  return request('/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(project),
+  });
+}
+
+export function updateProject(id, project) {
+  return request(`/projects/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(project),
+  });
+}
+
+export function deleteProject(id) {
+  return request(`/projects/${id}`, { method: 'DELETE' });
+}
+
+export function getLeaders() {
+  return request('/leaders');
+}
+
+export function createLeader(leader) {
+  return request('/leaders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(leader),
+  });
+}
+
+export function deleteLeader(id) {
+  return request(`/leaders/${id}`, { method: 'DELETE' });
+}

--- a/my_app/frontend/vite.config.js
+++ b/my_app/frontend/vite.config.js
@@ -7,4 +7,9 @@ export default defineConfig({
     outDir: '../static',
     emptyOutDir: true,
   },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add API service layer for frontend
- show loading and error states in React components
- use proxy config for development
- document SPA workflow in docs

## Testing
- `black my_app/app my_app/tests`
- `isort my_app/app my_app/tests`
- `flake8 my_app/app`
- `mypy app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c6a5e9240832998ad67cb3ff051ec